### PR TITLE
Issue 32 to rename "LastUpdated" to "last_updated"

### DIFF
--- a/checkers/btc/Dockerfile
+++ b/checkers/btc/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84-slim-bullseye AS builder
+FROM rust:1.82-slim-bullseye AS builder
 
 WORKDIR /usr/src/app
 

--- a/checkers/btc/src/worker/mod.rs
+++ b/checkers/btc/src/worker/mod.rs
@@ -31,7 +31,6 @@ struct ServerData {
     height: u64,
     #[serde(rename = "server_version")]
     electrum_version: String,
-    #[serde(rename = "LastUpdated")]
     last_updated: chrono::DateTime<chrono::Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     ping: Option<f64>,
@@ -110,7 +109,7 @@ impl Worker {
                         .and_then(|v| v.as_str())
                         .unwrap_or(&request.version)
                         .to_string(),
-                    last_updated: chrono::Utc::now(),
+                    last_updated: Utc::now(),
                     ping: data.get("ping").and_then(|v| v.as_f64()),
                     error: false,
                     error_type: None,
@@ -127,7 +126,7 @@ impl Worker {
                     port: request.port,
                     height: 0,
                     electrum_version: request.version.clone(),
-                    last_updated: chrono::Utc::now(),
+                    last_updated: Utc::now(),
                     ping: None,
                     error: true,
                     error_type: Some("connection_error".to_string()),

--- a/checkers/btc/src/worker/mod.rs
+++ b/checkers/btc/src/worker/mod.rs
@@ -109,7 +109,7 @@ impl Worker {
                         .and_then(|v| v.as_str())
                         .unwrap_or(&request.version)
                         .to_string(),
-                    last_updated: Utc::now(),
+                    last_updated: chrono::Utc::now(),
                     ping: data.get("ping").and_then(|v| v.as_f64()),
                     error: false,
                     error_type: None,
@@ -126,7 +126,7 @@ impl Worker {
                     port: request.port,
                     height: 0,
                     electrum_version: request.version.clone(),
-                    last_updated: Utc::now(),
+                    last_updated: chrono::Utc::now(),
                     ping: None,
                     error: true,
                     error_type: Some("connection_error".to_string()),

--- a/checkers/http/Dockerfile
+++ b/checkers/http/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84-slim-bullseye as builder
+FROM rust:1.82-slim-bullseye AS builder
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \

--- a/checkers/zec/Dockerfile
+++ b/checkers/zec/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84-slim-bullseye AS builder
+FROM rust:1.82-slim-bullseye AS builder
 
 WORKDIR /usr/src/app
 

--- a/checkers/zec/src/main.rs
+++ b/checkers/zec/src/main.rs
@@ -22,7 +22,6 @@ struct CheckResult {
     height: u64,
     status: String,
     error: Option<String>,
-    #[serde(rename = "LastUpdated")]
     last_updated: DateTime<Utc>,
     ping: f64,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/discovery/Dockerfile
+++ b/discovery/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75-slim as builder
+FROM rust:1.82-slim-bullseye AS builder
 
 RUN apt-get update && apt-get install -y \
     pkg-config \

--- a/publisher/Dockerfile
+++ b/publisher/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84-slim-bullseye AS builder
+FROM rust:1.82-slim-bullseye AS builder
 
 WORKDIR /usr/src/app
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84-slim-bullseye as builder
+FROM rust:1.82-slim-bullseye AS builder
 
 WORKDIR /usr/src/app
 

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -57,7 +57,7 @@ struct ServerInfo {
     #[serde(default)]
     height: u64,
 
-    #[serde(rename = "LastUpdated", default)]
+    #[serde(default)]
     last_updated: Option<String>,
 
     #[serde(default)]
@@ -368,7 +368,7 @@ async fn network_status(
 
         match serde_json::from_str::<ServerInfo>(&value) {
             Ok(mut server_info) => {
-                // Skip servers without LastChecked
+                // Skip servers without last_updated
                 if server_info.last_updated.is_none() {
                     continue;
                 }


### PR DESCRIPTION
I created a branch off main that renames the LastUpdated fields to last_updated. I did not maintain backwards compatibility with the old redis, so we'd have to remake it all with new names. Or include handling for LastUpdated and last_updated. 

This branch also included the discovery.py (assuming an un-merged issue-28 branch), which will be replaced by rust. I'm not sure exactly why the banner above says this can't be automatically merged, so other potential issues there. 

Options: 
-> Merge this one to rename to last_updated, and remake the redis. Then merge in discovery.py -> rust issue-28
-> Merge in other PRs first, rebase issue-32 and request new PR