### PR TITLE
fix zaino rocket

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,6 +183,7 @@ services:
     ports:
       - "8080:8080"
     environment:
+      - RUST_LOG=${RUST_LOG:-warn}
       - CLICKHOUSE_HOST=chronicler
       - CLICKHOUSE_PORT=8123
       - CLICKHOUSE_USER=${CLICKHOUSE_USER}


### PR DESCRIPTION

1. **Docker Compose Changes**:
   - Added `RUST_LOG=${RUST_LOG:-warn}` environment variable to control logging level, defaulting to "warn" if not set

2. **Logging System Changes**:
   - Switched from `tracing_subscriber::FmtSubscriber` to `tracing_subscriber::fmt()`
   - Added environment-based log filtering using `EnvFilter::from_default_env()`
   - Removed hardcoded `Level::INFO` in favor of environment variable control

3. **Server Version Display Changes**:
   - Simplified the Zaino server detection logic
   - Now checks for "Zaino" in the vendor field instead of checking version string format
   - Removed the currency-specific check for ZEC

4. **Server Response Processing Changes**:
   - Removed debug logging of raw server responses
   - Simplified server info parsing by directly deserializing into `ServerInfo` struct
   - Removed manual field-by-field parsing in favor of automatic deserialization
   - Removed complex error message parsing and cleaning logic
   - Improved error reporting with more context in error messages

5. **Code Cleanup**:
   - Removed redundant string conversions and transformations
   - Simplified version string handling
   - Removed unnecessary debug logging statements
   - Streamlined the server response processing pipeline

