### PR TITLE
feat: add marinade.duckdns.org community Zcash lightwalletd node

### DIFF
--- a/crates/hosh-discovery/src/lib.rs
+++ b/crates/hosh-discovery/src/lib.rs
@@ -315,6 +315,7 @@ const ZEC_SERVERS: &[(&str, u16, bool)] = &[
         443,
         true,
     ),
+    ("marinade.duckdns.org", 443, true),
 ];
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary

- Adds `marinade.duckdns.org:443` as a community Zcash lightwalletd node to the discovery list.